### PR TITLE
Adding query_id to the response headers

### DIFF
--- a/src/main/java/org/opensearch/ubl/UserBehaviorLoggingPlugin.java
+++ b/src/main/java/org/opensearch/ubl/UserBehaviorLoggingPlugin.java
@@ -10,11 +10,7 @@ package org.opensearch.ubl;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ubl.action.UserBehaviorLoggingRestHandler;
-import org.opensearch.ubl.action.UserBehaviorLoggingSearchFilter;
 import org.opensearch.action.support.ActionFilter;
-import org.opensearch.ubl.backends.Backend;
-import org.opensearch.ubl.backends.OpenSearchBackend;
 import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
@@ -24,7 +20,6 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
-import org.opensearch.ubl.events.EventManager;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
@@ -32,6 +27,11 @@ import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.ubl.action.UserBehaviorLoggingActionFilter;
+import org.opensearch.ubl.action.UserBehaviorLoggingRestHandler;
+import org.opensearch.ubl.backends.Backend;
+import org.opensearch.ubl.backends.OpenSearchBackend;
+import org.opensearch.ubl.events.EventManager;
 import org.opensearch.watcher.ResourceWatcherService;
 
 import java.util.ArrayList;
@@ -98,7 +98,7 @@ public class UserBehaviorLoggingPlugin extends Plugin implements ActionPlugin {
     ) {
 
         this.backend = new OpenSearchBackend(client);
-        this.userBehaviorLoggingFilter =  new UserBehaviorLoggingSearchFilter(backend, environment.settings());
+        this.userBehaviorLoggingFilter =  new UserBehaviorLoggingActionFilter(backend, environment.settings(), threadPool);
 
         LOGGER.info("Creating scheduled task");
 

--- a/src/main/java/org/opensearch/ubl/action/UserBehaviorLoggingActionFilter.java
+++ b/src/main/java/org/opensearch/ubl/action/UserBehaviorLoggingActionFilter.java
@@ -16,8 +16,10 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.ubl.model.QueryResponse;
 import org.opensearch.ubl.backends.Backend;
 import org.opensearch.ubl.model.QueryRequest;
@@ -25,16 +27,18 @@ import org.opensearch.tasks.Task;
 
 import java.util.*;
 
-public class UserBehaviorLoggingSearchFilter implements ActionFilter {
+public class UserBehaviorLoggingActionFilter implements ActionFilter {
 
-    private static final Logger LOGGER = LogManager.getLogger(UserBehaviorLoggingSearchFilter.class);
+    private static final Logger LOGGER = LogManager.getLogger(UserBehaviorLoggingActionFilter.class);
 
     private final Backend backend;
     private final Settings settings;
+    private final ThreadPool threadPool;
 
-    public UserBehaviorLoggingSearchFilter(final Backend backend, final Settings settings) {
+    public UserBehaviorLoggingActionFilter(final Backend backend, final Settings settings, ThreadPool threadPool) {
         this.backend = backend;
         this.settings = settings;
+        this.threadPool = threadPool;
     }
 
     @Override
@@ -57,6 +61,8 @@ public class UserBehaviorLoggingSearchFilter implements ActionFilter {
             @Override
             public void onResponse(Response response) {
 
+                LOGGER.info("Query ID header: " + task.getHeader("query-id"));
+
                 final long startTime = System.currentTimeMillis();
 
                 // Get the search itself.
@@ -67,19 +73,19 @@ public class UserBehaviorLoggingSearchFilter implements ActionFilter {
                 //final Set<String> indicesToLog = new HashSet<>(Arrays.asList(settings.get(SettingsConstants.INDEX_NAMES).split(",")));
                 //if(indicesToLog.containsAll(indices)) {
 
-                    // Create a UUID for this search request.
-                    final String queryId = UUID.randomUUID().toString();
-
-                    // The query will be empty when there is no query, e.g. /_search
-                    final String query = searchRequest.source().toString();
-
-                    // Create a UUID for this search response.
-                    final String queryResponseId = UUID.randomUUID().toString();
-
-                    final List<String> queryResponseHitIds = new LinkedList<>();
-
                     // Get all search hits from the response.
                     if (response instanceof SearchResponse) {
+
+                        // Create a UUID for this search request.
+                        final String queryId = UUID.randomUUID().toString();
+
+                        // The query will be empty when there is no query, e.g. /_search
+                        final String query = searchRequest.source().toString();
+
+                        // Create a UUID for this search response.
+                        final String queryResponseId = UUID.randomUUID().toString();
+
+                        final List<String> queryResponseHitIds = new LinkedList<>();
 
                         final SearchResponse searchResponse = (SearchResponse) response;
 
@@ -100,6 +106,8 @@ public class UserBehaviorLoggingSearchFilter implements ActionFilter {
                             // TODO: Handle this.
                             LOGGER.error("Unable to persist query.", ex);
                         }
+
+                        threadPool.getThreadContext().addResponseHeader("query_id", queryId);
 
                     }
 


### PR DESCRIPTION
Adding query_id to the response headers for #9.

I'm not sure if this a robust solution and the "right" way to do it, but based on old documentation it should work at least for our purposes right now.

The query ID is set in a `query_id` header:

```
curl -v http://localhost:9200/.awesome_events/_search 
*   Trying 127.0.0.1:9200...
* Connected to localhost (127.0.0.1) port 9200 (#0)
> GET /.awesome_events/_search HTTP/1.1
> Host: localhost:9200
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< query_id: f2bad461-19cf-41cf-bda5-f6885df0525b                              <------ query_id
< content-type: application/json; charset=UTF-8
< content-length: 502
```


