### PR TITLE
Making the events queue abstract to future support other backends

### DIFF
--- a/src/main/java/org/opensearch/ubl/UserBehaviorLoggingPlugin.java
+++ b/src/main/java/org/opensearch/ubl/UserBehaviorLoggingPlugin.java
@@ -24,7 +24,7 @@ import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
 import org.opensearch.env.NodeEnvironment;
-import org.opensearch.ubl.events.EventManager;
+import org.opensearch.ubl.events.OpenSearchEventManager;
 import org.opensearch.plugins.ActionPlugin;
 import org.opensearch.plugins.Plugin;
 import org.opensearch.repositories.RepositoriesService;
@@ -102,9 +102,10 @@ public class UserBehaviorLoggingPlugin extends Plugin implements ActionPlugin {
 
         LOGGER.info("Creating scheduled task");
 
-        // TODO: Only start this if already initialized.
+        // TODO: Only start this if an OpenSearch store is already initialized.
+        // Otherwise, start it when a store is initialized.
         threadPool.scheduler().scheduleAtFixedRate(() -> {
-            EventManager.getInstance(client).process();
+            OpenSearchEventManager.getInstance(client).process();
         }, 0, 2000, TimeUnit.MILLISECONDS);
 
         return Collections.emptyList();

--- a/src/main/java/org/opensearch/ubl/action/UserBehaviorLoggingRestHandler.java
+++ b/src/main/java/org/opensearch/ubl/action/UserBehaviorLoggingRestHandler.java
@@ -72,8 +72,8 @@ public class UserBehaviorLoggingRestHandler extends BaseRestHandler {
                 final String storeName = request.param("store");
 
                 LOGGER.info("Persisting event into {}", storeName);
-                final String event = request.content().utf8ToString();
-                backend.persistEvent(storeName, event);
+                final String eventJson = request.content().utf8ToString();
+                backend.persistEvent(storeName, eventJson);
 
                 return (channel) -> channel.sendResponse(new BytesRestResponse(RestStatus.OK, "Event received"));
 

--- a/src/main/java/org/opensearch/ubl/action/UserBehaviorLoggingSearchFilter.java
+++ b/src/main/java/org/opensearch/ubl/action/UserBehaviorLoggingSearchFilter.java
@@ -16,8 +16,10 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilter;
 import org.opensearch.action.support.ActionFilterChain;
 import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.action.ActionResponse;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.ubl.model.QueryResponse;
 import org.opensearch.ubl.backends.Backend;
 import org.opensearch.ubl.model.QueryRequest;
@@ -67,20 +69,19 @@ public class UserBehaviorLoggingSearchFilter implements ActionFilter {
                 //final Set<String> indicesToLog = new HashSet<>(Arrays.asList(settings.get(SettingsConstants.INDEX_NAMES).split(",")));
                 //if(indicesToLog.containsAll(indices)) {
 
-                    // Create a UUID for this search request.
-                    final String queryId = UUID.randomUUID().toString();
-
-                    // The query will be empty when there is no query, e.g. /_search
-                    final String query = searchRequest.source().toString();
-
-                    // Create a UUID for this search response.
-                    final String queryResponseId = UUID.randomUUID().toString();
-
-                    final List<String> queryResponseHitIds = new LinkedList<>();
-
                     // Get all search hits from the response.
                     if (response instanceof SearchResponse) {
 
+                        // Create a UUID for this search request.
+                        final String queryId = UUID.randomUUID().toString();
+
+                        // The query will be empty when there is no query, e.g. /_search
+                        final String query = searchRequest.source().toString();
+
+                        // Create a UUID for this search response.
+                        final String queryResponseId = UUID.randomUUID().toString();
+
+                        final List<String> queryResponseHitIds = new LinkedList<>();
                         final SearchResponse searchResponse = (SearchResponse) response;
 
                         // Add each hit to the list of query responses.
@@ -100,6 +101,8 @@ public class UserBehaviorLoggingSearchFilter implements ActionFilter {
                             // TODO: Handle this.
                             LOGGER.error("Unable to persist query.", ex);
                         }
+
+                        // TODO: Somehow return the queryId to the client.
 
                     }
 

--- a/src/main/java/org/opensearch/ubl/backends/Backend.java
+++ b/src/main/java/org/opensearch/ubl/backends/Backend.java
@@ -20,7 +20,7 @@ public interface Backend {
 
     void delete(final String storeName, RestChannel channel);
 
-    void persistEvent(final String storeName, String event);
+    void persistEvent(final String storeName, String eventJson);
 
     void persistQuery(final String storeName, QueryRequest queryRequest, QueryResponse queryResponse) throws Exception;
 

--- a/src/main/java/org/opensearch/ubl/events/AbstractEventManager.java
+++ b/src/main/java/org/opensearch/ubl/events/AbstractEventManager.java
@@ -1,0 +1,31 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ubl.events;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.index.IndexRequest;
+import org.opensearch.ubl.events.queues.EventQueue;
+import org.opensearch.ubl.events.queues.InternalQueue;
+
+public abstract class AbstractEventManager {
+
+    private final Logger LOGGER = LogManager.getLogger(AbstractEventManager.class);
+
+    protected final EventQueue eventQueue;
+
+    public AbstractEventManager() {
+        this.eventQueue = new InternalQueue();
+    }
+
+    public abstract void process();
+
+    public abstract void add(Event event);
+
+}

--- a/src/main/java/org/opensearch/ubl/events/Event.java
+++ b/src/main/java/org/opensearch/ubl/events/Event.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ubl.events;
+
+public class Event {
+
+    private final String indexName;
+    private final String event;
+
+    public Event(String indexName, String event) {
+        this.indexName = indexName;
+        this.event = event;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public String getEvent() {
+        return event;
+    }
+
+}

--- a/src/main/java/org/opensearch/ubl/events/queues/EventQueue.java
+++ b/src/main/java/org/opensearch/ubl/events/queues/EventQueue.java
@@ -9,16 +9,17 @@
 package org.opensearch.ubl.events.queues;
 
 import org.opensearch.action.index.IndexRequest;
+import org.opensearch.ubl.events.Event;
 
 import java.util.List;
 
 public interface EventQueue {
 
-    void add(IndexRequest indexRequest);
+    void add(Event event);
 
     void clear();
 
-    List<IndexRequest> get();
+    List<Event> get();
 
     int size();
 

--- a/src/main/java/org/opensearch/ubl/events/queues/InternalQueue.java
+++ b/src/main/java/org/opensearch/ubl/events/queues/InternalQueue.java
@@ -8,18 +8,18 @@
 
 package org.opensearch.ubl.events.queues;
 
-import org.opensearch.action.index.IndexRequest;
+import org.opensearch.ubl.events.Event;
 
 import java.util.LinkedList;
 import java.util.List;
 
 public class InternalQueue implements EventQueue {
 
-    private static final List<IndexRequest> indexRequests = new LinkedList<>();
+    private static final List<Event> indexRequests = new LinkedList<>();
 
     @Override
-    public void add(IndexRequest indexRequest) {
-        indexRequests.add(indexRequest);
+    public void add(Event event) {
+        indexRequests.add(event);
     }
 
     @Override
@@ -28,7 +28,7 @@ public class InternalQueue implements EventQueue {
     }
 
     @Override
-    public List<IndexRequest> get() {
+    public List<Event> get() {
         return indexRequests;
     }
 


### PR DESCRIPTION
I made the event queue interface to be abstract so there can be event queues for other backends. Right now there is just one implementation of `AbstractEventManager` and it is `OpenSearchEventManager`.