### PR TITLE
Adding header to determine appropriate query store

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ curl -s http://localhost:9200/.awesome_events/_search -H 'Content-Type: applicat
 Get queries:
 
 ```
-curl -s http://localhost:9200/.awesome_queries/_search | jq
+curl -s http://localhost:9200/.awesome_queries/_search -H "X-ubi-store: awesome" | jq
 ```
 
 Delete the store:

--- a/src/main/java/org/opensearch/ubl/HeaderConstants.java
+++ b/src/main/java/org/opensearch/ubl/HeaderConstants.java
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.ubl;
+
+public class HeaderConstants {
+
+    public static final String EVENT_STORE_HEADER = "X-ubi-store";
+
+}

--- a/src/main/java/org/opensearch/ubl/UserBehaviorLoggingPlugin.java
+++ b/src/main/java/org/opensearch/ubl/UserBehaviorLoggingPlugin.java
@@ -10,6 +10,7 @@ package org.opensearch.ubl;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.rest.RestHeaderDefinition;
 import org.opensearch.ubl.action.UserBehaviorLoggingRestHandler;
 import org.opensearch.ubl.action.UserBehaviorLoggingSearchFilter;
 import org.opensearch.action.support.ActionFilter;
@@ -49,6 +50,16 @@ public class UserBehaviorLoggingPlugin extends Plugin implements ActionPlugin {
 
     private Backend backend;
     private ActionFilter userBehaviorLoggingFilter;
+
+    @Override
+    public Collection<RestHeaderDefinition> getRestHeaders() {
+        return List.of(new RestHeaderDefinition(HeaderConstants.EVENT_STORE_HEADER, false));
+    }
+
+    @Override
+    public Collection<String> getTaskHeaders() {
+        return List.of(HeaderConstants.EVENT_STORE_HEADER);
+    }
 
     @Override
     public List<RestHandler> getRestHandlers(final Settings settings,


### PR DESCRIPTION
For #16, this changes the plugin to expect a header value that indicates the name of the store being used. This may be a temporary solution but will suffice for purposes now. 